### PR TITLE
Force upgrade to pyqtgraph 0.11 (for Py38 especially)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ee10a8841449fa6a805493287fb6d366ce254637b7ceb0771902892d57b7e2c2
 
 build:
-  number: 2
+  number: 3
   skip: True  # [py<36 or linux]
   entry_points:
     - iris = iris.gui:run
@@ -27,7 +27,7 @@ requirements:
     - pyqt >=5,<6
     - qdarkstyle ==2.7
     - scikit-ued >=2.0.2, <2.1.0
-    - pyqtgraph >=0.10,<1
+    - pyqtgraph >=0.11,<1
     - npstreams ==1.6.2
     - crystals >=1, <2
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
